### PR TITLE
NO-TICKET propagate sign in styling changes from base to both apps

### DIFF
--- a/govuk-cosmetics/login/login.ftl
+++ b/govuk-cosmetics/login/login.ftl
@@ -3,9 +3,16 @@
     <#if section = "title">
         ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "header">
-        ${msg("loginTitleHtml",(realm.displayNameHtml!''))?no_esc}
+        ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "form">
         <#if realm.password>
+        <#--
+            Hack-alert: Keycloak doesn't provide per-field error messages here,
+            so we check global message for need to display validation error styling
+        -->
+        <#if message?has_content && message.type = "error">
+            <#assign errorClass = "govuk-form-group--error" >
+        </#if>
         <div class="govuk-grid-row">
             <#if realm.registrationAllowed && !usernameEditDisabled??>
                 <div id="kc-registration" class="govuk-grid-column-full">
@@ -14,16 +21,12 @@
             </#if>
 
             <form id="kc-form-login" class="${properties.kcFormClass!} govuk-grid-column-two-thirds" action="${url.loginAction}" method="post">
-                <div class="govuk-form-group">
+                <div class="govuk-form-group ${errorClass!""}">
                     <label for="username" class="govuk-label"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
-                    <#if usernameEditDisabled??>
-                        <input id="username" class="govuk-input" name="username" value="${(login.username!'')}" type="text" disabled />
-                    <#else>
-                        <input id="username" class="govuk-input" name="username" value="${(login.username!'')}" type="text" autofocus autocomplete="off" />
-                    </#if>
+                    <input id="username" class="govuk-input" name="username" value="${(login.username!'')}" type="text" autofocus autocomplete="off" />
                 </div>
 
-                <div class="govuk-form-group">
+                <div class="govuk-form-group ${errorClass!""}">
                     <label for="password" class="govuk-label">${msg("password")}</label>
                     <input id="password" class="govuk-input" name="password" type="password" autocomplete="off" />
                 </div>
@@ -46,13 +49,15 @@
                 </div>
 
                 <input class="govuk-button" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+            </form>
 
+            <div class="govuk-grid-column-full">
                 <div class="${properties.kcFormOptionsWrapperClass!} govuk-form-group">
                     <#if realm.resetPasswordAllowed>
                         <p><a class="govuk-link govuk-body" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></p>
                     </#if>
                 </div>
-            </form>
+            </div>
         </div>
         </#if>
     <#elseif section = "info" >

--- a/govuk-cosmetics/login/messages/messages_en.properties
+++ b/govuk-cosmetics/login/messages/messages_en.properties
@@ -1,5 +1,4 @@
 loginTitle=Sign in to Notify Cosmetics
-loginTitleHtml=Sign in to Notify Cosmetics
 registerText=If you don''t already have an account,
 registerLink=create an account
 

--- a/govuk-mspsds/login/login.ftl
+++ b/govuk-mspsds/login/login.ftl
@@ -3,21 +3,25 @@
     <#if section = "title">
         ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "header">
-        ${msg("loginTitleHtml",(realm.displayNameHtml!''))?no_esc}
+        ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "form">
         <#if realm.password>
+        <#--
+            Hack-alert: Keycloak doesn't provide per-field error messages here,
+            so we check global message for need to display validation error styling
+        -->
+        <#if message?has_content && message.type = "error">
+            <#assign errorClass = "govuk-form-group--error" >
+        </#if>
         <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full"><p>${msg("noAccountInstruction", msg("administrator"))}</p></div>
             <form id="kc-form-login" class="${properties.kcFormClass!} govuk-grid-column-two-thirds" action="${url.loginAction}" method="post">
-                <div class="govuk-form-group">
+                <div class="govuk-form-group ${errorClass!""}">
                     <label for="username" class="govuk-label"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
-                    <#if usernameEditDisabled??>
-                        <input id="username" class="govuk-input" name="username" value="${(login.username!'')}" type="text" disabled />
-                    <#else>
-                        <input id="username" class="govuk-input" name="username" value="${(login.username!'')}" type="text" autofocus autocomplete="off" />
-                    </#if>
+                    <input id="username" class="govuk-input" name="username" value="${(login.username!'')}" type="text" autofocus autocomplete="off" />
                 </div>
 
-                <div class="govuk-form-group">
+                <div class="govuk-form-group ${errorClass!""}">
                     <label for="password" class="govuk-label">${msg("password")}</label>
                     <input id="password" class="govuk-input" name="password" type="password" autocomplete="off" />
                 </div>
@@ -40,13 +44,14 @@
                 </div>
 
                 <input class="govuk-button" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
-
+            </form>
+            <div class="govuk-grid-column-full">
                 <div class="${properties.kcFormOptionsWrapperClass!} govuk-form-group">
                     <#if realm.resetPasswordAllowed>
                         <p><a class="govuk-link govuk-body" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></p>
                     </#if>
                 </div>
-            </form>
+            </div>
         </div>
         </#if>
     <#elseif section = "info" >

--- a/govuk/login/login.ftl
+++ b/govuk/login/login.ftl
@@ -45,22 +45,16 @@
 
                 <input class="govuk-button" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
             </form>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="${properties.kcFormOptionsWrapperClass!} govuk-form-group">
-                <#if realm.resetPasswordAllowed>
-                    <p><a class="govuk-link govuk-body" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></p>
-                </#if>
+            <div class="govuk-grid-column-full">
+                <div class="${properties.kcFormOptionsWrapperClass!} govuk-form-group">
+                    <#if realm.resetPasswordAllowed>
+                        <p><a class="govuk-link govuk-body" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></p>
+                    </#if>
+                </div>
             </div>
         </div>
         </#if>
     <#elseif section = "info" >
-        <#if realm.password && realm.registrationAllowed && !usernameEditDisabled??>
-            <div id="kc-registration">
-                <h2 class="heading-medium">${msg("noAccount")}</h2>
-                <p><a href="${url.registrationUrl}">${msg("registerLink")}</a></p>
-            </div>
-        </#if>
 
         <#if realm.password && social.providers??>
             <#-- This section of the theme has not yet been well styled. Non-trivial user research, interaction design and content design work is required to develop a solution for login using 3rd-party identity providers. -->


### PR DESCRIPTION
It seems that changes from MSPSDS-896 and split between cosmetics and
mspsds sign-in pages coincided in time and thus got missed out in the
now-split off versions.
This should bring them back in line