### PR TITLE
COSBETA-80: Set up analytics

### DIFF
--- a/govuk-cosmetics/login/login.ftl
+++ b/govuk-cosmetics/login/login.ftl
@@ -12,7 +12,7 @@
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', 'GA_MEASUREMENT_ID');
+          gtag('config', 'UA-126364208-2');
         </script>
         <#if realm.password>
         <#--

--- a/govuk-cosmetics/login/login.ftl
+++ b/govuk-cosmetics/login/login.ftl
@@ -5,6 +5,15 @@
     <#elseif section = "header">
         ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "form">
+        <!-- Global Site Tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-126364208-2"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', 'GA_MEASUREMENT_ID');
+        </script>
         <#if realm.password>
         <#--
             Hack-alert: Keycloak doesn't provide per-field error messages here,

--- a/govuk-cosmetics/login/register.ftl
+++ b/govuk-cosmetics/login/register.ftl
@@ -12,7 +12,7 @@
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', 'GA_MEASUREMENT_ID');
+          gtag('config', 'UA-126364208-2');
         </script>
         <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
           <input type="text" readonly value="this is not a login form" style="display: none;">

--- a/govuk-cosmetics/login/register.ftl
+++ b/govuk-cosmetics/login/register.ftl
@@ -5,6 +5,15 @@
     <#elseif section = "header">
         ${msg("registerWithTitleHtml",(realm.displayNameHtml!''))?no_esc}
     <#elseif section = "form">
+        <!-- Global Site Tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-126364208-2"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', 'GA_MEASUREMENT_ID');
+        </script>
         <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
           <input type="text" readonly value="this is not a login form" style="display: none;">
           <input type="password" readonly value="this is not a login form" style="display: none;">

--- a/govuk-mspsds/login/login.ftl
+++ b/govuk-mspsds/login/login.ftl
@@ -12,7 +12,7 @@
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', 'GA_MEASUREMENT_ID');
+          gtag('config', 'UA-126364208-1');
         </script>
         <#if realm.password>
         <#--

--- a/govuk-mspsds/login/login.ftl
+++ b/govuk-mspsds/login/login.ftl
@@ -5,6 +5,15 @@
     <#elseif section = "header">
         ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "form">
+        <!-- Global Site Tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-126364208-1"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', 'GA_MEASUREMENT_ID');
+        </script>
         <#if realm.password>
         <#--
             Hack-alert: Keycloak doesn't provide per-field error messages here,


### PR DESCRIPTION
Google analytics suggests adding their tag right after `<head>`, but I'm not sure if it's easily achievable here. 

I want to have different id in that tag, so that mspsds login and cosmetics login/registration don't send data to the same google analytics property. I want that because we actually use the same domain for them(at least for int/staging), which makes creating filters separating the two difficult. 

Reading up on the internet suggests the tag will work anywhere(and in fact it was suggested to put it at the end of body before), but putting it right after head makes sure a user stopping site from loading doesn't break our analytics. 

I'm not sure there is a simple solution(like storing google id in something like theme.properties) that avoids the issue of analytics not working when users stop site from loading. Thoughts? 