### PR TITLE
MSPSDS-1103: Create terms and conditions page

### DIFF
--- a/govuk-mspsds/login/login.ftl
+++ b/govuk-mspsds/login/login.ftl
@@ -75,5 +75,20 @@
                 </ul>
             </div>
         </#if>
+    <#elseif section = "footer_links">
+        <div class="govuk-clearfix govuk-!-margin-bottom-2">
+            <span>
+                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" rel="noopener" href="/terms-and-conditions?referred=true">Terms and conditions</a>
+                <span class="govuk-visually-hidden">(opens new window)</span>
+            </span>
+            <span>
+                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" rel="noopener" href="/privacy-policy?referred=true">Privacy policy</a>
+                <span class="govuk-visually-hidden">(opens new window)</span>
+            </span>
+            <span>
+                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" rel="noopener" href="/about?referred=true">About this service</a>
+                <span class="govuk-visually-hidden">(opens new window)</span>
+            </span>
+        </div>
     </#if>
 </@layout.registrationLayout>

--- a/govuk-mspsds/login/login.ftl
+++ b/govuk-mspsds/login/login.ftl
@@ -78,15 +78,15 @@
     <#elseif section = "footer_links">
         <div class="govuk-clearfix govuk-!-margin-bottom-2">
             <span>
-                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" rel="noopener" href="/terms-and-conditions?referred=true">Terms and conditions</a>
+                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" href="/help/terms-and-conditions">Terms and conditions</a>
                 <span class="govuk-visually-hidden">(opens new window)</span>
             </span>
             <span>
-                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" rel="noopener" href="/privacy-policy?referred=true">Privacy policy</a>
+                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" href="/help/privacy-policy">Privacy policy</a>
                 <span class="govuk-visually-hidden">(opens new window)</span>
             </span>
             <span>
-                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" rel="noopener" href="/about?referred=true">About this service</a>
+                <a class="govuk-footer__link govuk-!-margin-right-2" target="_blank" href="/help/about">About this service</a>
                 <span class="govuk-visually-hidden">(opens new window)</span>
             </span>
         </div>

--- a/govuk/login/template.ftl
+++ b/govuk/login/template.ftl
@@ -216,6 +216,7 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
         <div class="govuk-width-container ">
             <div class="govuk-footer__meta">
             <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                <#nested "footer_links">
 
                 <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
                 <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"


### PR DESCRIPTION
Part of adding terms and condition page(and a few others) to MSPSDS service includes adding them to the footer. This makes sure that they are also visible on the login page for MSPSDS. I cheked that(locally) it doesn't break or alter cosmetics login footer. 

They are hard-coded for prod, because I didn't find a clever way of making them refer to current environment. 